### PR TITLE
TEST: Expected warning messages for deprecated parameters

### DIFF
--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -282,7 +282,7 @@ def deprecated_params(
         # No warning
 
         foo(a=2, b=3, z=4)
-        # WARNING  The parameters a and b of function foo have been deprecated and may be removed in a future version.
+        # WARNING  The parameters a and b of method foo have been deprecated and may be removed in a later version.
 
     You can also specify additional information for a more precise warning::
 
@@ -296,7 +296,7 @@ def deprecated_params(
             pass
 
         foo(a=2)
-        # WARNING  The parameter a of function foo has been deprecated since v0.2 and is expected to be removed after v0.4. The letters x, y, z are cooler.
+        # WARNING  The parameter a of method foo has been deprecated since v0.2 and is expected to be removed after v0.4. The letters x, y, z are cooler.
 
     Basic parameter redirection::
 
@@ -309,7 +309,7 @@ def deprecated_params(
             return kwargs
 
         foo(x=1, old_param=2)
-        # WARNING  The parameter old_param of function foo has been deprecated and may be removed in a future version.
+        # WARNING  The parameter old_param of method foo has been deprecated and may be removed in a later version.
         # returns {"x": 1, "new_param": 2}
 
     Redirecting using a calculated value::
@@ -321,7 +321,7 @@ def deprecated_params(
             return kwargs
 
         foo(runtime_in_ms=500)
-        # WARNING  The parameter runtime_in_ms of function foo has been deprecated and may be removed in a future version.
+        # WARNING  The parameter runtime_in_ms of method foo has been deprecated and may be removed in a later version.
         # returns {"run_time": 0.5}
 
     Redirecting multiple parameter values to one::
@@ -333,7 +333,7 @@ def deprecated_params(
             return kwargs
 
         foo(buff_x=2)
-        # WARNING  The parameter buff_x of function foo has been deprecated and may be removed in a future version.
+        # WARNING  The parameter buff_x of method foo has been deprecated and may be removed in a later version.
         # returns {"buff": (2, 1)}
 
     Redirect one parameter to multiple::
@@ -346,11 +346,11 @@ def deprecated_params(
             return kwargs
 
         foo(buff=0)
-        # WARNING  The parameter buff of function foo has been deprecated and may be removed in a future version.
+        # WARNING  The parameter buff of method foo has been deprecated and may be removed in a later version.
         # returns {"buff_x": 0, buff_y: 0}
 
         foo(buff=(1,2))
-        # WARNING  The parameter buff of function foo has been deprecated and may be removed in a future version.
+        # WARNING  The parameter buff of method foo has been deprecated and may be removed in a later version.
         # returns {"buff_x": 1, buff_y: 2}
 
 

--- a/manim/utils/deprecation.py
+++ b/manim/utils/deprecation.py
@@ -301,7 +301,7 @@ def deprecated_params(
     Basic parameter redirection::
 
         @deprecated_params(redirections=[
-            #Two ways to redirect one parameter to another:
+            # Two ways to redirect one parameter to another:
             ("old_param", "new_param"),
             lambda old_param2: {"new_param22": old_param2}
         ])

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -185,6 +185,10 @@ class Top:
     def bar(self, **kwargs):
         pass
 
+    @deprecated_params(redirections=[("old_param", "new_param")])
+    def baz(self, **kwargs):
+        return kwargs
+
 
 def test_deprecate_func_no_args(caplog):
     """Test the deprecation of a method (decorator with no arguments)."""
@@ -267,3 +271,16 @@ def test_deprecate_func_single_param_since_and_until(caplog):
         msg
         == "The parameter a of method Top.bar has been deprecated since v0.2 and is expected to be removed after v0.4."
     )
+
+
+def test_deprecate_func_param_redirect_tuple(caplog):
+    """Test the deprecation of an old method parameter and redirecting it to a new one."""
+    t = Top()
+    obj = t.baz(x=1, old_param=2)
+    assert len(caplog.record_tuples) == 1
+    msg = _get_caplog_record_msg(caplog)
+    assert (
+        msg
+        == "The parameter old_param of method Top.baz has been deprecated and may be removed in a later version."
+    )
+    assert obj == {"x": 1, "new_param": 2}

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -195,6 +195,14 @@ class Top:
     def qux(self, **kwargs):
         return kwargs
 
+    @deprecated_params(
+        redirections=[
+            lambda point2D_x=1, point2D_y=1: {"point2D": (point2D_x, point2D_y)}
+        ]
+    )
+    def quux(self, **kwargs):
+        return kwargs
+
 
 def test_deprecate_func_no_args(caplog):
     """Test the deprecation of a method (decorator with no arguments)."""
@@ -303,3 +311,16 @@ def test_deprecate_func_param_redirect_lambda(caplog):
         == "The parameter runtime_in_ms of method Top.qux has been deprecated and may be removed in a later version."
     )
     assert obj == {"run_time": 0.5}
+
+
+def test_deprecate_func_param_redirect_many_to_one(caplog):
+    """Test the deprecation of multiple method parameters and redirecting them to one."""
+    t = Top()
+    obj = t.quux(point2D_x=3, point2D_y=5)
+    assert len(caplog.record_tuples) == 1
+    msg = _get_caplog_record_msg(caplog)
+    assert (
+        msg
+        == "The parameters point2D_x and point2D_y of method Top.quux have been deprecated and may be removed in a later version."
+    )
+    assert obj == {"point2D": (3, 5)}

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -203,6 +203,16 @@ class Top:
     def quux(self, **kwargs):
         return kwargs
 
+    @deprecated_params(
+        redirections=[
+            lambda point2D=1: {"x": point2D[0], "y": point2D[1]}
+            if isinstance(point2D, tuple)
+            else {"x": point2D, "y": point2D}
+        ]
+    )
+    def quuz(self, **kwargs):
+        return kwargs
+
 
 def test_deprecate_func_no_args(caplog):
     """Test the deprecation of a method (decorator with no arguments)."""
@@ -324,3 +334,27 @@ def test_deprecate_func_param_redirect_many_to_one(caplog):
         == "The parameters point2D_x and point2D_y of method Top.quux have been deprecated and may be removed in a later version."
     )
     assert obj == {"point2D": (3, 5)}
+
+
+def test_deprecate_func_param_redirect_one_to_many(caplog):
+    """Test the deprecation of one method parameter and redirecting it to many."""
+    t = Top()
+    obj1 = t.quuz(point2D=0)
+    assert len(caplog.record_tuples) == 1
+    msg = _get_caplog_record_msg(caplog)
+    assert (
+        msg
+        == "The parameter point2D of method Top.quuz has been deprecated and may be removed in a later version."
+    )
+    assert obj1 == {"x": 0, "y": 0}
+
+    caplog.clear()
+
+    obj2 = t.quuz(point2D=(2, 3))
+    assert len(caplog.record_tuples) == 1
+    msg = _get_caplog_record_msg(caplog)
+    assert (
+        msg
+        == "The parameter point2D of method Top.quuz has been deprecated and may be removed in a later version."
+    )
+    assert obj2 == {"x": 2, "y": 3}

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -189,6 +189,12 @@ class Top:
     def baz(self, **kwargs):
         return kwargs
 
+    @deprecated_params(
+        redirections=[lambda runtime_in_ms: {"run_time": runtime_in_ms / 1000}]
+    )
+    def qux(self, **kwargs):
+        return kwargs
+
 
 def test_deprecate_func_no_args(caplog):
     """Test the deprecation of a method (decorator with no arguments)."""
@@ -274,7 +280,7 @@ def test_deprecate_func_single_param_since_and_until(caplog):
 
 
 def test_deprecate_func_param_redirect_tuple(caplog):
-    """Test the deprecation of an old method parameter and redirecting it to a new one."""
+    """Test the deprecation of a method parameter and redirecting it to a new one using tuple."""
     t = Top()
     obj = t.baz(x=1, old_param=2)
     assert len(caplog.record_tuples) == 1
@@ -284,3 +290,16 @@ def test_deprecate_func_param_redirect_tuple(caplog):
         == "The parameter old_param of method Top.baz has been deprecated and may be removed in a later version."
     )
     assert obj == {"x": 1, "new_param": 2}
+
+
+def test_deprecate_func_param_redirect_lambda(caplog):
+    """Test the deprecation of a method parameter and redirecting it to a new one using lambda function."""
+    t = Top()
+    obj = t.qux(runtime_in_ms=500)
+    assert len(caplog.record_tuples) == 1
+    msg = _get_caplog_record_msg(caplog)
+    assert (
+        msg
+        == "The parameter runtime_in_ms of method Top.qux has been deprecated and may be removed in a later version."
+    )
+    assert obj == {"run_time": 0.5}

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -257,7 +257,7 @@ def test_deprecate_func_params(caplog):
     )
 
 
-def test_deprecate_func_params_single_since_and_until(caplog):
+def test_deprecate_func_single_param_since_and_until(caplog):
     """Test the deprecation of a single method parameter (decorator with since and until arguments)."""
     t = Top()
     t.bar(a=1, b=2)

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -181,6 +181,10 @@ class Top:
     def foo(self, **kwargs):
         pass
 
+    @deprecated_params(params="a", since="v0.2", until="v0.4")
+    def bar(self, **kwargs):
+        pass
+
 
 def test_deprecate_func_no_args(caplog):
     """Test the deprecation of a method (decorator with no arguments)."""
@@ -250,4 +254,16 @@ def test_deprecate_func_params(caplog):
     assert (
         msg
         == "The parameters a and b of method Top.foo have been deprecated and may be removed in a later version."
+    )
+
+
+def test_deprecate_func_params_single_since_and_until(caplog):
+    """Test the deprecation of a single method parameter (decorator with since and until arguments)."""
+    t = Top()
+    t.bar(a=1, b=2)
+    assert len(caplog.record_tuples) == 1
+    msg = _get_caplog_record_msg(caplog)
+    assert (
+        msg
+        == "The parameter a of method Top.bar has been deprecated since v0.2 and is expected to be removed after v0.4."
     )

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -177,7 +177,7 @@ class Top:
 
             return nested_func
 
-    @deprecated_params(params="a, b, c")
+    @deprecated_params(params="a, b, c", message="Use something else.")
     def foo(self, **kwargs):
         pass
 
@@ -281,7 +281,7 @@ def test_deprecate_func_params(caplog):
     msg = _get_caplog_record_msg(caplog)
     assert (
         msg
-        == "The parameters a and b of method Top.foo have been deprecated and may be removed in a later version."
+        == "The parameters a and b of method Top.foo have been deprecated and may be removed in a later version. Use something else."
     )
 
 


### PR DESCRIPTION
Test the expected warning messages for deprecated parameters:
```py
@deprecated_params(params="a, b, c", message="Use something else.")
@deprecated_params(params="a", since="v0.2", until="v0.4")
@deprecated_params(redirections=[("old_param", "new_param")])
@deprecated_params(
    redirections=[lambda runtime_in_ms: {"run_time": runtime_in_ms / 1000}]
)
@deprecated_params(
    redirections=[
        lambda point2D_x=1, point2D_y=1: {"point2D": (point2D_x, point2D_y)}
    ]
)
@deprecated_params(
    redirections=[
        lambda point2D=1: {"x": point2D[0], "y": point2D[1]}
        if isinstance(point2D, tuple)
        else {"x": point2D, "y": point2D}
    ]
)
```

Tests for deprecated docstrings coming soon.